### PR TITLE
feat: supports custom delimiters and template references

### DIFF
--- a/classfile.go
+++ b/classfile.go
@@ -66,6 +66,9 @@ func (p *App) Patch(path string, handle func(ctx *Context)) {
 func (p *App) Static__0(pattern string, dir ...fs.FS) {
 	p.Static(pattern, dir...)
 }
+func (p *App) Delims(left, right string) {
+	p.SetDelims(left, right)
+}
 
 // Static serves static files from a http file system scheme (url).
 // See https://pkg.go.dev/github.com/qiniu/x/http/fsx for more information.

--- a/demo/blog/blog.go
+++ b/demo/blog/blog.go
@@ -8,12 +8,19 @@ import (
 
 func main() {
 	y := yap.New(os.DirFS("."))
-
+	y.SetDelims("${", "}")
 	y.GET("/p/:id", func(ctx *yap.Context) {
 		ctx.YAP(200, "article", yap.H{
-			"id": ctx.Param("id"),
+			"id":   1,
+			"Name": "aaaa",
+			"Base": "bbbbb",
+			"URL":  "http://fefawd.baidu.com",
+			"Ann":  true,
+			"Items": []string{
+				"awdawd",
+			},
 		})
 	})
 
-	y.Run(":8080")
+	y.Run("127.0.0.1:8080")
 }

--- a/demo/blog/yap/article_yap.html
+++ b/demo/blog/yap/article_yap.html
@@ -3,6 +3,17 @@
 <meta charset="utf-8"/>
 </head>
 <body>
+    {{ template "header"}}
 Article {{.id}}
+<pre>{{
+$name := .Name
+$base := .Base
+}}
+{{
+    .Name
+    .Base
+}}
+${ .Name }
+</pre>
 </body>
 </html>

--- a/demo/blog/yap/header_yap.html
+++ b/demo/blog/yap/header_yap.html
@@ -1,0 +1,3 @@
+{{ define "header"}}
+<h2>hello world</h2>
+{{ end}}

--- a/internal/templ/template.go
+++ b/internal/templ/template.go
@@ -20,16 +20,16 @@ import (
 	"strings"
 )
 
-func Translate(text string) string {
+func Translate(text, left, right string) string {
 	offs := make([]int, 0, 16)
 	base := 0
 	for {
-		pos := strings.Index(text[base:], "{{")
+		pos := strings.Index(text[base:], left)
 		if pos < 0 {
 			break
 		}
 		begin := base + pos + 2 // script begin
-		n := strings.Index(text[begin:], "}}")
+		n := strings.Index(text[begin:], right)
 		if n < 0 {
 			n = len(text) - begin // script length
 		}

--- a/internal/templ/template_test.go
+++ b/internal/templ/template_test.go
@@ -78,12 +78,17 @@ end
 </html>
 `
 
+var (
+	left  = "{{"
+	right = "}}"
+)
+
 func TestTranslate(t *testing.T) {
-	if ret := Translate(yapScriptIn); ret != yapScriptOut {
+	if ret := Translate(yapScriptIn, left, right); ret != yapScriptOut {
 		t.Fatal("TestTranslate:", len(ret), len(yapScriptOut), len(yapScriptIn)+11*4, ret)
 	}
 	noScript := "abc"
-	if Translate(noScript) != noScript {
+	if Translate(noScript, left, right) != noScript {
 		t.Fatal("translate(noScript)")
 	}
 	noScriptEnd := `{{abc
@@ -92,7 +97,7 @@ efg
 	noScriptEndOut := `{{abc}}{{
 efg
 `
-	if ret := Translate(noScriptEnd); ret != noScriptEndOut {
+	if ret := Translate(noScriptEnd, left, right); ret != noScriptEndOut {
 		t.Fatal("translate(noScriptEnd):", ret)
 	}
 }

--- a/template.go
+++ b/template.go
@@ -17,28 +17,42 @@
 package yap
 
 import (
+	"fmt"
 	"html/template"
 	"io/fs"
+	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/goplus/yap/internal/templ"
 )
 
-// Template is the representation of a parsed template. The *parse.Tree
-// field is exported only for use by html/template and should be treated
-// as unexported by all other clients.
+type Delims struct {
+	Left  string
+	Right string
+}
 type Template struct {
 	*template.Template
+	fsys   fs.FS
+	delims Delims
 }
 
-// NewTemplate allocates a new, undefined template with the given name.
-func NewTemplate(name string) Template {
-	return Template{template.New(name)}
+func NewTemplate(name string) *Template {
+	return &Template{template.New(name), nil, Delims{"{{", "}}"}}
+}
+func (t *Template) NewTemplate(name string) *Template {
+	return &Template{Template: t.Template.New(name), fsys: t.fsys, delims: Delims{"{{", "}}"}}
 }
 
 func (t Template) Parse(text string) (ret Template, err error) {
-	ret.Template, err = t.Template.Parse(templ.Translate(text))
+	ret.Template, err = t.Template.Parse(templ.Translate(text, t.delims.Left, t.delims.Right))
 	return
+}
+
+func (t *Template) SetDelims(delims Delims) {
+	t.delims = delims
+	t.Delims(t.delims.Left, t.delims.Right)
 }
 
 func ParseFSFile(f fs.FS, file string) (t Template, err error) {
@@ -48,4 +62,112 @@ func ParseFSFile(f fs.FS, file string) (t Template, err error) {
 	}
 	name := filepath.Base(file)
 	return NewTemplate(name).Parse(string(b))
+}
+
+func ParseFiles(filenames ...string) (*Template, error) {
+	return parseFiles(nil, readFileOS, filenames...)
+}
+
+func (t *Template) ParseFiles(filenames ...string) (*Template, error) {
+	return parseFiles(t, readFileOS, filenames...)
+}
+
+func parseFiles(t *Template, readFile func(string) (string, []byte, error), filenames ...string) (*Template, error) {
+
+	if len(filenames) == 0 {
+		return nil, fmt.Errorf("yap/template: no files named in call to ParseFiles")
+	}
+	for _, filename := range filenames {
+		name, b, err := readFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		s := string(b)
+		var tmpl *Template
+		if t == nil {
+			t = NewTemplate(name)
+		}
+		if name == t.Name() {
+			tmpl = t
+		} else {
+			tmpl = t.NewTemplate(name)
+		}
+		_, err = tmpl.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
+}
+
+func ParseGlob(pattern string) (*Template, error) {
+	return parseGlob(nil, pattern)
+}
+
+func (t *Template) ParseGlob(pattern string) (*Template, error) {
+	return parseGlob(t, pattern)
+}
+
+func parseGlob(t *Template, pattern string) (*Template, error) {
+	filenames, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	if len(filenames) == 0 {
+		return nil, fmt.Errorf("html/template: pattern matches no files: %#q", pattern)
+	}
+	return parseFiles(t, readFileOS, filenames...)
+}
+
+// IsTrue reports whether the value is 'true', in the sense of not the zero of its type,
+// and whether the value has a meaningful truth value. This is the definition of
+// truth used by if and other such actions.
+func IsTrue(val any) (truth, ok bool) {
+	return template.IsTrue(val)
+}
+
+// ParseFS is like ParseFiles or ParseGlob but reads from the file system fs
+// instead of the host operating system's file system.
+// It accepts a list of glob patterns.
+// (Note that most file names serve as glob patterns matching only themselves.)
+func ParseFS(fs fs.FS, patterns ...string) (*Template, error) {
+	return parseFS(nil, fs, patterns)
+}
+
+// ParseFS is like ParseFiles or ParseGlob but reads from the file system fs
+// instead of the host operating system's file system.
+// It accepts a list of glob patterns.
+// (Note that most file names serve as glob patterns matching only themselves.)
+func (t *Template) ParseFS(fs fs.FS, patterns ...string) (*Template, error) {
+	return parseFS(t, fs, patterns)
+}
+
+func parseFS(t *Template, fsys fs.FS, patterns []string) (*Template, error) {
+	var filenames []string
+	for _, pattern := range patterns {
+		list, err := fs.Glob(fsys, pattern)
+		if err != nil {
+			return nil, err
+		}
+		if len(list) == 0 {
+			return nil, fmt.Errorf("template: pattern matches no files: %#q", pattern)
+		}
+		filenames = append(filenames, list...)
+	}
+	return parseFiles(t, readFileFS(fsys), filenames...)
+}
+
+func readFileOS(file string) (name string, b []byte, err error) {
+	name = filepath.Base(file)
+	b, err = os.ReadFile(file)
+	return
+}
+
+func readFileFS(fsys fs.FS) func(string) (string, []byte, error) {
+	return func(file string) (name string, b []byte, err error) {
+		name = path.Base(file)
+		name = strings.TrimSuffix(name, "_yap.html")
+		b, err = fs.ReadFile(fsys, file)
+		return
+	}
 }


### PR DESCRIPTION
support include other tempalte
support custom delimiter: {{ . }} => ${ . }

default: Template loaded on first access to HTML

> load tempalte: yap.LoadTemplate()

> set delims: yap.SetDelims("${", "}")


The official code used to parse the template's code